### PR TITLE
Add Jest unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# elastic-movies
-elastic search movies repository w front and wsp
+# Elastic Movies API
+
+Base project using Node.js, Express and Elasticsearch. The API provides a minimal example for indexing and searching movie documents.
+
+## Requirements
+- Node.js 14+
+- Access to an Elasticsearch instance (default: `http://localhost:9200`)
+
+## Installation
+
+```bash
+npm install
+```
+
+## Running tests
+
+```bash
+npm test
+```
+
+## Running the server
+
+```bash
+npm start
+```
+
+The server listens on `http://localhost:3000` by default. Use `PORT` and `ELASTIC_NODE` environment variables to customize the configuration.
+
+## Available endpoints
+- `POST /movies` – index a movie document (JSON body)
+- `GET /movies/:id` – retrieve a movie by id
+- `GET /search?q=<term>` – search movies by title

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "elastic-movies",
+  "version": "1.0.0",
+  "description": "elastic search movies repository w front and wsp",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "@elastic/elasticsearch": "^8.11.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  }
+}

--- a/src/__tests__/app.test.js
+++ b/src/__tests__/app.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+const createApp = require('../app');
+
+describe('movies API', () => {
+  let app;
+  let client;
+
+  beforeEach(() => {
+    client = {
+      index: jest.fn(),
+      get: jest.fn(),
+      search: jest.fn(),
+    };
+    app = createApp(client);
+  });
+
+  test('POST /movies indexes a movie', async () => {
+    client.index.mockResolvedValue({ body: { result: 'created' } });
+    await request(app)
+      .post('/movies')
+      .send({ title: 'test' })
+      .expect(201, { result: 'created' });
+    expect(client.index).toHaveBeenCalled();
+  });
+
+  test('GET /movies/:id retrieves a movie', async () => {
+    client.get.mockResolvedValue({ body: { _source: { title: 'hello' } } });
+    await request(app)
+      .get('/movies/1')
+      .expect(200, { title: 'hello' });
+    expect(client.get).toHaveBeenCalledWith({ index: 'movies', id: '1' });
+  });
+
+  test('GET /search queries movies', async () => {
+    client.search.mockResolvedValue({ body: { hits: { hits: [{ _id: '1', _source: { title: 't' } }] } } });
+    await request(app)
+      .get('/search?q=t')
+      .expect(200, [{ id: '1', title: 't' }]);
+    expect(client.search).toHaveBeenCalled();
+  });
+});
+

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,43 @@
+const express = require('express');
+
+module.exports = function createApp(client) {
+  const app = express();
+  app.use(express.json());
+
+  app.post('/movies', async (req, res) => {
+    try {
+      const { body } = await client.index({
+        index: 'movies',
+        document: req.body,
+      });
+      res.status(201).json({ result: body.result });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.get('/movies/:id', async (req, res) => {
+    try {
+      const { id } = req.params;
+      const { body } = await client.get({ index: 'movies', id });
+      res.json(body._source);
+    } catch (err) {
+      res.status(404).json({ error: 'Not Found' });
+    }
+  });
+
+  app.get('/search', async (req, res) => {
+    try {
+      const { q } = req.query;
+      const { body } = await client.search({
+        index: 'movies',
+        query: { match: { title: q } }
+      });
+      res.json(body.hits.hits.map(hit => ({ id: hit._id, ...hit._source })));
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  return app;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,14 @@
+const { Client } = require('@elastic/elasticsearch');
+const createApp = require('./app');
+
+const client = new Client({ node: process.env.ELASTIC_NODE || 'http://localhost:9200' });
+const app = createApp(client);
+const port = process.env.PORT || 3000;
+
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- add Jest and Supertest for unit testing
- refactor server into app creator for easier testing
- export Express app in `src/index.js`
- document how to run tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@elastic%2felasticsearch)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843829ffdb883288d1e815535e1f0d8